### PR TITLE
bug/getAddress() non-existent

### DIFF
--- a/hardhat/scripts/deploy.ts
+++ b/hardhat/scripts/deploy.ts
@@ -26,7 +26,7 @@ async function main() {
     console.log(`Deploying contract ${contractName} with parameters: ${params}...`);
     const deployResponse: BaseContract = await factory.deploy(...paramsParsed);
     console.log(`Contract ${contractName} deployed successfully!`);
-    storeAddressInfo(contractName, await deployResponse.getAddress());
+    storeAddressInfo(contractName, deployResponse.address);
   }
 
   console.log(`Saving contract addresses for ${hre.network.name}`);


### PR DESCRIPTION
We change the non-existent `getAddress()` function in the` deployResponse` object to the `address `attribute.
Removed unnecessary `await`.